### PR TITLE
upgraded uglifyJS to beta version that allows ES6 minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "tslint": "5.5.0",
     "tslint-loader": "3.5.3",
     "typescript": "2.4.2",
+    "uglifyjs-webpack-plugin": "^1.0.0-beta.1",
     "webfontloader": "1.6.28",
     "webpack": "3.4.1",
     "webpack-dev-server": "2.6.1",

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,6 +3,7 @@ var path = require('path');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CleanWebpackPlugin = require('clean-webpack-plugin');
 var WebpackShellPlugin = require('webpack-shell-plugin');
+const Uglify = require("uglifyjs-webpack-plugin");
 
 module.exports = {
     entry: path.join(__dirname, 'src/app.ts'),
@@ -44,7 +45,7 @@ module.exports = {
         new CleanWebpackPlugin([
             path.join(__dirname, 'dist')
         ]),
-        new webpack.optimize.UglifyJsPlugin({
+        new Uglify({
             compress: {
                 warnings: false
             },


### PR DESCRIPTION
Builiding distribution with ES6 is not possible unless the newest beta version of UglifyJS is used.  These modifications all the building of ES6 code.