### PR TITLE
Added support for VSCode debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ builds
 
 # Visual Studio
 .vs
-.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Run Server DEV",
+            "port": 9222,
+            "url": "http://localhost:9000/",
+            "webRoot": "${workspaceRoot}",
+            "sourceMaps": true,
+            "timeout": 15000,
+            "trace": "verbose",
+            "preLaunchTask": "run_server_dev",
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Run Server DIST",
+            "port": 9222,
+            "url": "http://localhost:9000/",
+            "webRoot": "${workspaceRoot}",
+            "sourceMaps": true,
+            "timeout": 15000,
+            "trace": "verbose",
+            "preLaunchTask": "run_server_dist",
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,18 +15,6 @@
             "timeout": 15000,
             "trace": "verbose",
             "preLaunchTask": "run_server_dev",
-        },
-        {
-            "type": "chrome",
-            "request": "launch",
-            "name": "Run Server DIST",
-            "port": 9222,
-            "url": "http://localhost:9000/",
-            "webRoot": "${workspaceRoot}",
-            "sourceMaps": true,
-            "timeout": 15000,
-            "trace": "verbose",
-            "preLaunchTask": "run_server_dist",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,14 +10,6 @@
             "label": "(Start) Webpack Dev Server",
             "identifier": "run_server_dev",
             "promptOnClose": true
-        },
-        {
-            "type": "npm",
-            "script": "server:dist",
-            "problemMatcher": [],
-            "label": "(Start) Webpack Dist Server",
-            "identifier": "run_server_dist",
-            "promptOnClose": true
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "server:dev",
+            "problemMatcher": [],
+            "label": "(Start) Webpack Dev Server",
+            "identifier": "run_server_dev",
+            "promptOnClose": true
+        },
+        {
+            "type": "npm",
+            "script": "server:dist",
+            "problemMatcher": [],
+            "label": "(Start) Webpack Dist Server",
+            "identifier": "run_server_dist",
+            "promptOnClose": true
+        }
+    ]
+}


### PR DESCRIPTION
Hi, this PR adds support for native debugging in VSCode. It is similar to what @Nepoxx suggested on #11, but I also added the `tasks.json` file. This way, I can use the `"preLaunchTask"` attribute to start the server and the debugger at the same time.
I added just one debug config, for `server:dev`. And of course, I had to change `.gitignore` to include those files.

I believe this will help and encourage those who are using VSCode as their IDE.